### PR TITLE
libXss.so is named libXss.so.1 in ubuntu

### DIFF
--- a/snakefire/pxss.py
+++ b/snakefire/pxss.py
@@ -27,8 +27,10 @@
 from ctypes import * 
 
 
-libXss = CDLL('libXss.so')
-
+try:
+    libXss = CDLL('libXss.so')
+except OSError:
+    libXss = CDLL('libXss.so.1')
 
 class Screen(Structure):
   _fields_ = [


### PR DESCRIPTION
Therefore, it fails on startup, added a quick exception check to contemplate both names.

EDIT: It may be a exclusive error of my install (using the 11.10 beta), so maybe requires more testing or other user cases.
