### PR TITLE
Better handle links that are not 200's

### DIFF
--- a/snakefire/renderers.py
+++ b/snakefire/renderers.py
@@ -113,12 +113,16 @@ class MessageRenderer(QtCore.QThread):
             return self._renderInlineLink(message_url, message_url)
 
         headers = response.info()
+        url = message_url
+        if response.getcode == '200':
+            url = response.geturl()
+
         meta = {
-            'name': response.geturl(),
+            'name': url,
             'type': headers["Content-Type"]
         }
 
-        return self._renderInline(url=response.geturl(), meta=meta)
+        return self._renderInline(url=url, meta=meta)
 
     def _displayUpload(self):
         request = urllib2.Request(self._message.upload['url'])


### PR DESCRIPTION
Frequently, people in our Campfire rooms post links to password protected sites(internal Github) that send a 302 to a login page. The current code will show the redirected link to the login page loosing the original URL.

Might be a better way to do this, but this change looks for a 200 status code and uses the original URL in the rendering if it's not 200.
