### PR TITLE
Fix for issue #51

### DIFF
--- a/snakefire/qtx.py
+++ b/snakefire/qtx.py
@@ -168,7 +168,7 @@ class SpellAction(Qt.QAction):
     def __init__(self, *args):
         super(SpellAction, self).__init__(*args)
         self.triggered.connect(lambda x: self.correct.emit(
-            unicode(self.text())))
+            unicode(self.toolTip())))
 
 class IdleTimer(QtCore.QThread):
     def __init__(self, parent, idleSeconds):


### PR DESCRIPTION
Instead of using the text attribute from the spell menu, use the toolTip. QT is auto-generating/changing the spelling suggestions to include accelerator(inserting &'s) markup. The toolTip isn't effected. I couldn't find a way to tell QT to not do this, so this is a workaround.
