### PR TITLE
Hide annoying images

### DIFF
--- a/snakefire/mainframe.py
+++ b/snakefire/mainframe.py
@@ -895,10 +895,10 @@ class Snakefire(object):
         topicLabel.setToolTip(self._("Click here to change room's topic"))
         topicLabel.setWordWrap(True)
         self.connect(topicLabel, QtCore.SIGNAL("clicked()"), self.changeTopic)
+
         view = SnakeFireWebView(self)
         view.setSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Expanding)
         frame = view.page().mainFrame()
-
 
         #Send all link clicks to systems web browser
         view.page().setLinkDelegationPolicy(QtWebKit.QWebPage.DelegateAllLinks)


### PR DESCRIPTION
We have an internal chat that posts lots of annoying images/gifs, this adds a button to each image that can hide/show the image. Would probably be nicer as a right click option instead of a button and could also collapse the image Div, instead of simply hiding.
