### PR TITLE
Check for DBUS Notifications service presence

### DIFF
--- a/builds/arch/PKGBUILD
+++ b/builds/arch/PKGBUILD
@@ -6,7 +6,7 @@ pkgdesc='A Campfire desktop client'
 arch=('i686' 'x86_64' 'ppc')
 url='http://snakefire.org'
 license=('MIT')
-depends=('python2' 'python2-pyqt4' 'python2-keyring' 'python2-notify' 'python-pyfire>=0.3.4')
+depends=('python2' 'python2-pyqt4' 'python2-keyring' 'python2-notify' 'python-pyfire>=0.3.4', 'python2-dbus')
 optdepends=('python-gnomekeyring: For GNOME/XFCE/LXDE users that require notifications' 'python2-pyenchant: For spell checking support')
 makedepends=('python2' 'python2-distribute')
 source=(http://snakefire.org/downloads/$pkgname-$pkgver.tar.gz)

--- a/snakefire/__init__.py
+++ b/snakefire/__init__.py
@@ -1,7 +1,7 @@
 import os, resources, subprocess
+import dbus, dbus.proxies
 
-GNOME_ENABLED = os.getenv("GNOME_DESKTOP_SESSION_ID")
-XFCE_ENABLED = os.getenv("XDG_SESSION_COOKIE")
+NOTIFICATIONS_ENABLED = False
 KDE_ENABLED = False
 
 try:
@@ -10,10 +10,17 @@ try:
 except OSError:
     pass
 
+try:
+    dbus.proxies.ProxyObject(conn=dbus.SessionBus(),
+                             bus_name="org.freedesktop.Notifications",
+                             object_path="/org/freedesktop/Notifications")
+    NOTIFICATIONS_ENABLED = True
+except dbus.exceptions.DBusException:
+    pass
 
 if KDE_ENABLED:
     from .mainframe import KSnakefire as Snakefire
-elif GNOME_ENABLED or XFCE_ENABLED:
+elif NOTIFICATIONS_ENABLED:
     from .mainframe import GSnakefire as Snakefire
 else:
     from .mainframe import QSnakefire as Snakefire

--- a/snakefire/mainframe.py
+++ b/snakefire/mainframe.py
@@ -8,7 +8,7 @@ import time
 import urllib2
 import enchant
 
-from snakefire import GNOME_ENABLED, KDE_ENABLED, XFCE_ENABLED
+from snakefire import NOTIFICATIONS_ENABLED, KDE_ENABLED
 
 from PyQt4 import Qt
 from PyQt4 import QtGui
@@ -18,7 +18,7 @@ from PyQt4 import QtWebKit
 if KDE_ENABLED:
     from PyKDE4 import kdecore
     from PyKDE4 import kdeui
-elif GNOME_ENABLED or XFCE_ENABLED:
+elif NOTIFICATIONS_ENABLED:
     import subprocess
     import pynotify
 
@@ -1149,7 +1149,7 @@ if KDE_ENABLED:
                 kdeui.KNotification.CloseWhenWidgetActivated
             )
 
-if GNOME_ENABLED or XFCE_ENABLED:
+if NOTIFICATIONS_ENABLED:
     class GSnakefire(QSnakefire):
         def __init__(self, parent=None):
             super(GSnakefire, self).__init__(parent)


### PR DESCRIPTION
Instead of checking for the presence of particular environment
variables, set by Desktop Environments, we should check if there is
any service on DBus that listens to org.freedesktop.Notifications.

This is important for people who use different services that provide
notification features like [Dunst](https://github.com/knopwob/dunst).

See [this link](https://wiki.archlinux.org/index.php/Desktop_Notifications) for a more detailed list.
